### PR TITLE
Custom Bot MS page no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Export the URL as `MS_TEAMS_SEND_URL`
 
 ### Reply to messages
 
-Hubot can reply to messages via the [custom bot](https://msdn.microsoft.com/en-us/microsoft-teams/custombot) interface.
+Hubot can reply to messages via the [API or .Net](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/bots/bots-conversations#replying-to-messages) interface.
 
 TODO


### PR DESCRIPTION
The old "Custom Bot" link no longer exists.  I replaced that URL with one that looks appropriate.  The new URL basically covers the same in terms of how to reply to messages.